### PR TITLE
declare dependency on JSON component of SDK.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "acquia/acquia-sdk-php-env": "self.version"
+        "acquia/acquia-sdk-php-env": "self.version",
+        "acquia/acquia-sdk-php-json": "self.version"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
The CloudEnvironment class depends on the JSON component, but it's not declared as a dependency.
